### PR TITLE
final timestamp parsing and generation

### DIFF
--- a/test/support/test_schema.ex
+++ b/test/support/test_schema.ex
@@ -18,6 +18,8 @@ defmodule SchemaGenerator.TestSchema do
     field(:accepted_terms?, :boolean, default: false)
     belongs_to(:office, Office, foreign_key: :office_id)
     has_many(:posts, Post)
+
+    timestamps()
   end
 
   # A comment for testing comments


### PR DESCRIPTION
covers most of the edge cases with the timestamp function.

will not generate functions if the schema file leverages `@timestamps_opts` because that won't show up in the parsed file ast unless the attribute is included directly in the file and not through using a macro file.